### PR TITLE
Add self.build method for AttributeList

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    attribool (2.0.1)
+    attribool (2.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/attribool.rb
+++ b/lib/attribool.rb
@@ -10,6 +10,7 @@ require_relative "attribool/validators/condition_validator"
 require_relative "attribool/validators/method_name_validator"
 require_relative "attribool/validators/nil_attribute_validator"
 require_relative "attribool/validators/strict_boolean_validator"
+require_relative "attribool/validators/attribute_list_validator"
 
 ##
 # Adds macros for dealing with boolean attributes.
@@ -44,7 +45,7 @@ module Attribool
   def bool_reader(*attributes, allow_nil: true, method_name: nil, condition: nil)
     ValidatorService.call(:method_name, method_name, attributes.size)
 
-    AttributeList.new(*attributes, method_name: method_name).each do |attribute|
+    AttributeList.build(*attributes, method_name: method_name).each do |attribute|
       define_method(attribute.reader) do
         instance_variable_get(attribute.ivar).then do |value|
           ValidatorService.call(:nil_attribute, attribute.ivar, value, allow_nil)
@@ -63,7 +64,7 @@ module Attribool
   #
   # @kwarg [Boolean] strict
   def bool_writer(*attributes, strict: false)
-    AttributeList.new(*attributes).each do |attribute|
+    AttributeList.build(*attributes).each do |attribute|
       define_method(attribute.writer) do |value|
         ValidatorService.call(:strict_boolean, value, strict)
 

--- a/lib/attribool/attribute_list.rb
+++ b/lib/attribool/attribute_list.rb
@@ -8,13 +8,24 @@ module Attribool
     include Enumerable
 
     ##
-    # Generate the list.
+    # Create an +AttributeList+ from a list of attribute names.
     #
-    # @param [String, Symbol] *attributes
+    # @param [String, Symbol] *attribute_names
     #
     # @kwarg [nil, String, Symbol, Proc] method_name
-    def initialize(*attributes, method_name: nil)
-      @entries = attributes.map { |a| Attribool::Attribute.new(a, method_name) }
+    #
+    # @return [AttributeList]
+    def self.build(*attribute_names, method_name: nil)
+      new(*attribute_names.map { |a| Attribool::Attribute.new(a, method_name) })
+    end
+
+    ##
+    # Construct the list.
+    #
+    # @param [String, Symbol] *attributes
+    def initialize(*attributes)
+      ValidatorService.call(:attribute_list, *attributes)
+      @entries = attributes
     end
 
     ##

--- a/lib/attribool/validators/attribute_list_validator.rb
+++ b/lib/attribool/validators/attribute_list_validator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Attribool::Validators
+  class AttributeListValidator
+    def initialize(*items)
+      @items = items
+    end
+
+    def valid?
+      @items.all?(Attribool::Attribute)
+    end
+
+    def error
+      TypeError.new("All items must be an instance of Attribool::Attribute")
+    end
+  end
+end

--- a/lib/attribool/version.rb
+++ b/lib/attribool/version.rb
@@ -21,7 +21,7 @@ module Attribool
     # Patch version.
     #
     # @return [Integer]
-    PATCH = 1
+    PATCH = 2
 
     module_function
 

--- a/test/attribool/attribute_list_test.rb
+++ b/test/attribool/attribute_list_test.rb
@@ -6,7 +6,7 @@ require_relative "../../lib/attribool/attribute_list"
 module Attribool
   class AttributeListTest < Test::Unit::TestCase
     def setup
-      @list = Attribool::AttributeList.new(:one, :two, :three)
+      @list = Attribool::AttributeList.build(:one, :two, :three)
     end
 
     def test_each
@@ -15,9 +15,21 @@ module Attribool
       assert_nothing_raised { @list.each(&:itself) }
     end
 
-    def test_initialize
+    def test_self_build
+      assert_nothing_raised do
+        Attribool::AttributeList.build(:one, :two, :three)
+      end
       @list.entries.each do |entry|
         assert_kind_of(Attribool::Attribute, entry)
+      end
+    end
+
+    def test_initialize
+      assert_nothing_raised do
+        Attribool::AttributeList.new(Attribool::Attribute.new(:one))
+      end
+      assert_raise(TypeError) do
+        Attribool::AttributeList.new(:one, :two, :three)
       end
     end
 

--- a/test/attribool/validators/attribute_list_validator_test.rb
+++ b/test/attribool/validators/attribute_list_validator_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/attribool/validators/attribute_list_validator"
+
+module Attribool::Validators
+  class AttributeListValidatorTest < Test::Unit::TestCase
+    def setup
+      @validator = Attribool::Validators::AttributeListValidator
+      @validator_sym = :attribute_list
+      @valid_argument_permutations = [
+        [Attribool::Attribute.new(:one), Attribool::Attribute.new(:two)]
+      ]
+      @invalid_argument_permutations = [
+        [:x]
+      ]
+      @error_class = TypeError
+    end
+
+    def test_initialize
+      assert_nothing_raised do
+        @validator.new(*@valid_argument_permutations.first)
+      end
+    end
+
+    def test_validate
+      @valid_argument_permutations.each do |args|
+        assert_nothing_raised { Attribool::ValidatorService.call(@validator_sym, *args) }
+        assert(@validator.new(*args).valid?)
+      end
+
+      @invalid_argument_permutations.each do |args|
+        assert_raise(@error_class) { Attribool::ValidatorService.call(@validator_sym, *args) }
+        refute(@validator.new(*args).valid?)
+      end
+    end
+
+    def test_error
+      assert_kind_of(
+        @error_class,
+        @validator.new(*@valid_argument_permutations.first).error
+      )
+    end
+  end
+end

--- a/test/attribool/validators/condition_validator_test.rb
+++ b/test/attribool/validators/condition_validator_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/attribool/validators/condition_validator"
+
+module Attribool::Validators
+  class ConditionValidatorTest < Test::Unit::TestCase
+    def setup
+      @validator = Attribool::Validators::ConditionValidator
+      @validator_sym = :condition
+      @valid_argument_permutations = [
+        [nil],
+        [proc {}]
+      ]
+      @invalid_argument_permutations = [
+        [:x]
+      ]
+      @error_class = ArgumentError
+    end
+
+    def test_initialize
+      assert_nothing_raised do
+        @validator.new(*@valid_argument_permutations.first)
+      end
+    end
+
+    def test_validate
+      @valid_argument_permutations.each do |args|
+        assert_nothing_raised { Attribool::ValidatorService.call(@validator_sym, *args) }
+        assert(@validator.new(*args).valid?)
+      end
+
+      @invalid_argument_permutations.each do |args|
+        assert_raise(@error_class) { Attribool::ValidatorService.call(@validator_sym, *args) }
+        refute(@validator.new(*args).valid?)
+      end
+    end
+
+    def test_error
+      assert_kind_of(
+        @error_class,
+        @validator.new(*@valid_argument_permutations.first).error
+      )
+    end
+  end
+end

--- a/test/attribool/validators/method_name_validator_test.rb
+++ b/test/attribool/validators/method_name_validator_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/attribool/validators/method_name_validator"
+
+module Attribool::Validators
+  class MethodNameValidatorTest < Test::Unit::TestCase
+    def setup
+      @validator = Attribool::Validators::MethodNameValidator
+      @validator_sym = :method_name
+      @valid_argument_permutations = [
+        [:x, 1],
+        [nil, 2],
+        [->(x) { x }, 2]
+      ]
+      @invalid_argument_permutations = [
+        [-> {}, 2],
+        [->(x, y) { "#{x}#{y}" }, 2]
+      ]
+      @error_class = ArgumentError
+    end
+
+    def test_initialize
+      assert_nothing_raised do
+        @validator.new(*@valid_argument_permutations.first)
+      end
+    end
+
+    def test_validate
+      @valid_argument_permutations.each do |args|
+        assert_nothing_raised { Attribool::ValidatorService.call(@validator_sym, *args) }
+        assert(@validator.new(*args).valid?)
+      end
+
+      @invalid_argument_permutations.each do |args|
+        assert_raise(@error_class) { Attribool::ValidatorService.call(@validator_sym, *args) }
+        refute(@validator.new(*args).valid?)
+      end
+    end
+
+    def test_error
+      assert_kind_of(
+        @error_class,
+        @validator.new(*@valid_argument_permutations.first).error
+      )
+    end
+  end
+end

--- a/test/attribool/validators/nil_attribute_validator_test.rb
+++ b/test/attribool/validators/nil_attribute_validator_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/attribool/validators/nil_attribute_validator"
+
+module Attribool::Validators
+  class NilAttributeValidatorTest < Test::Unit::TestCase
+    def setup
+      @validator = Attribool::Validators::NilAttributeValidator
+      @validator_sym = :nil_attribute
+      @valid_argument_permutations = [
+        [:@test, :test, false],
+        [:@test, nil, true]
+      ]
+      @invalid_argument_permutations = [
+        [:@test, nil, false]
+      ]
+      @error_class = TypeError
+    end
+
+    def test_initialize
+      assert_nothing_raised do
+        @validator.new(*@valid_argument_permutations.first)
+      end
+    end
+
+    def test_validate
+      @valid_argument_permutations.each do |args|
+        assert_nothing_raised { Attribool::ValidatorService.call(@validator_sym, *args) }
+        assert(@validator.new(*args).valid?)
+      end
+
+      @invalid_argument_permutations.each do |args|
+        assert_raise(@error_class) { Attribool::ValidatorService.call(@validator_sym, *args) }
+        refute(@validator.new(*args).valid?)
+      end
+    end
+
+    def test_error
+      assert_kind_of(
+        @error_class,
+        @validator.new(*@valid_argument_permutations.first).error
+      )
+    end
+  end
+end

--- a/test/attribool/validators/strict_boolean_validator_test.rb
+++ b/test/attribool/validators/strict_boolean_validator_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/attribool/validators/strict_boolean_validator"
+
+module Attribool::Validators
+  class StrictBooleanValidatorTest < Test::Unit::TestCase
+    def setup
+      @validator = Attribool::Validators::StrictBooleanValidator
+      @validator_sym = :strict_boolean
+      @valid_argument_permutations = [
+        [true, false],
+        [:test, false],
+        [true, true],
+        [false, true]
+      ]
+      @invalid_argument_permutations = [
+        [:test, true]
+      ]
+      @error_class = ArgumentError
+    end
+
+    def test_initialize
+      assert_nothing_raised do
+        @validator.new(*@valid_argument_permutations.first)
+      end
+    end
+
+    def test_validate
+      @valid_argument_permutations.each do |args|
+        assert_nothing_raised { Attribool::ValidatorService.call(@validator_sym, *args) }
+        assert(@validator.new(*args).valid?)
+      end
+
+      @invalid_argument_permutations.each do |args|
+        assert_raise(@error_class) { Attribool::ValidatorService.call(@validator_sym, *args) }
+        refute(@validator.new(*args).valid?)
+      end
+    end
+
+    def test_error
+      assert_kind_of(
+        @error_class,
+        @validator.new(*@valid_argument_permutations.first).error
+      )
+    end
+  end
+end


### PR DESCRIPTION
- AttributeList constructor now only accepts Attributes
- AttributeList.build will accept strings and convert to Attributes
- Added new validator for AttributeList
- Added test for new validator
- Fixed naming convention of validator tests